### PR TITLE
server: /random should do something by default

### DIFF
--- a/server/blink1-tiny-server.c
+++ b/server/blink1-tiny-server.c
@@ -350,6 +350,7 @@ static void ev_handler(struct mg_connection *nc, int ev, void *ev_data)
     }
     else if( mg_vcmp( uri, "/blink1/random") == 0 ) {
         sprintf(result, "blink1 random");
+        if( count==0 ) { count = 1; }
         if( millis==0 ) { millis = 200; }
         srand( time(NULL) * getpid() );
         blink1_device* dev = blink1_open();


### PR DESCRIPTION
without ?count=1 it was count=0, so "do nothing"

props to @wolfsage for telling me what was wrong, when I said "something is wrong"