### PR TITLE
Fix typo introduced by "clean up warnings"

### DIFF
--- a/server/blink1-tiny-server.c
+++ b/server/blink1-tiny-server.c
@@ -228,7 +228,7 @@ static void ev_handler(struct mg_connection *nc, int ev, void *ev_data)
             sprintf(tmpstr+strlen(tmpstr), "\"%s\"", blink1_getCachedSerial(i));
             if( i!=c-1 ) { sprintf(tmpstr+strlen(tmpstr), ","); } // ugh
         }
-        sprintf(tmpstr+strlen(tmpstr), "%s]",tmpstr);
+        sprintf(tmpstr+strlen(tmpstr), "]");
         DictionaryInsert(resultsdict, "blink1_serialnums", tmpstr);
         
         const char* blink1_serialnum = blink1_getCachedSerial(0);


### PR DESCRIPTION
Fix typo introduced by commit 0cd912d93a926b43641e9d67e9e388631070ed8b ("clean up warnings").