### PR TITLE
Fixed LED selection problem in blink1-tool --writepattern

### DIFF
--- a/blink1-tool.c
+++ b/blink1-tool.c
@@ -869,10 +869,8 @@ int main(int argc, char** argv)
         for( int i=0; i<pattlen; i++ ) {
             patternline_t pat = pattern[i];
 
-            if( pat.ledn>0 ) {
-                blink1_setLEDN(dev, pat.ledn);
-            }
             msg("writing line %d: %2.2x,%2.2x,%2.2x : %d : %d\n", i, pat.color.r,pat.color.g,pat.color.b, pat.millis,pat.ledn );
+            blink1_setLEDN(dev, pat.ledn);
             rc = blink1_writePatternLine(dev, pat.millis/2, pat.color.r, pat.color.g, pat.color.b, i);
         }
 


### PR DESCRIPTION
To recreate the problem, I first clear the pattern memory
```
$ blink1-tool --clearpattern
clearing pattern...done
$ blink1-tool --readpattern
read pattern:
{0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0}
```
Then  I add a short pattern which includes selecting individual LEDs.
```
$ blink1-tool --writepattern 0,#ff0000,2,1,#00ff00,2,2,#0000ff,2,0
write pattern: 0,#ff0000,2,1,#00ff00,2,2,#0000ff,2,0
writing line 0: ff,00,00 : 2000 : 1
writing line 1: 00,ff,00 : 2000 : 2
writing line 2: 00,00,ff : 2000 : 0
```
However when I read back the pattern, the entry number 2 is incorrectly addressing LED 2 instead of LED 0 (i.e. both LEDs)
```
$ blink1-tool --readpattern
read pattern:
{0,#ff0000,1.00,1,#00ff00,1.00,2,#0000ff,1.00,2,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0}
$ blink1-tool --getpattline 2
reading rgb at pos  2: r,g,b = 0x00,0x00,0xff (2) ms:1000
```
Doing the same test with my proposed change yields the expected result:
```
$ blink1-tool --readpattern
read pattern:
{0,#ff0000,1.00,1,#00ff00,1.00,2,#0000ff,1.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0,#000000,0.00,0}
$ blink1-tool --getpattline 2
reading rgb at pos  2: r,g,b = 0x00,0x00,0xff (0) ms:1000
```