### PR TITLE
Fixed times being divided by two when using --writepattern

### DIFF
--- a/blink1-tool.c
+++ b/blink1-tool.c
@@ -871,7 +871,7 @@ int main(int argc, char** argv)
 
             msg("writing line %d: %2.2x,%2.2x,%2.2x : %d : %d\n", i, pat.color.r,pat.color.g,pat.color.b, pat.millis,pat.ledn );
             blink1_setLEDN(dev, pat.ledn);
-            rc = blink1_writePatternLine(dev, pat.millis/2, pat.color.r, pat.color.g, pat.color.b, i);
+            rc = blink1_writePatternLine(dev, pat.millis, pat.color.r, pat.color.g, pat.color.b, i);
         }
 
     }


### PR DESCRIPTION
In the earlier pull request I didn't notice, that the times I used in the example pattern were divided by two when read back with `--readpattern.` Turns out, there was an unexpected division by two in the `--writepattern` code. 

Feel free to squash these changes into one commit if you want to streamline the history.