### PR TITLE
Create self contained source archives

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,6 @@ name: linux
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,6 +46,7 @@ jobs:
       - name: package up
         shell: bash
         run: |
+          make dist
           make package
           make package-tiny-server
           make package-blink1control-tool
@@ -55,5 +56,7 @@ jobs:
         uses: actions/upload-artifact@v2.2.2
         with:
           name: blink1-tools
-          path: builds/*
+          path: |
+            builds/*
+            srcdist/*
         

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ builds
 .vscode
 .idea
 cmake-build-debug
+
+# src archives
+srcdist


### PR DESCRIPTION
Hi,

This resolves #50 by creating self contained source archives and preserving the tag in those in a file named .git-tag in order to provide reproducible builds. The relevant steps are also invoked in the linux github action.

Notes:

- This PR contains 2 commits intentionally. The first commit just removes the master branch limitation for the linux github action. This was necessary to prove functionality on my branch in my fork. You can either revert this commit after merge or notify me to revert it before you merge. 
- The source archives are generated in srcdist/ (just like binaries in builds/)
- Since the automatic src archives generated by github can not be disabled (or can they?), you might want to put a note about choosing the correct source archives.

Cheers
 -Fritz