### PR TITLE
add missing LDFLAGS to library build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,7 @@ blink1-tiny-server: $(OBJS) blink1-tiny-server-html server/blink1-tiny-server.c
 	$(CC) $(CFLAGS) $(OBJS) $(EXEFLAGS) ./server/mongoose/mongoose.o $(LIBS) server/blink1-tiny-server-html.o server/blink1-tiny-server.o -o blink1-tiny-server$(EXE) $(LDFLAGS)
 
 $(LIBTARGET): $(OBJS)
-	$(CC) $(LIBFLAGS) $(CFLAGS) $(OBJS) $(LIBS)
+	$(CC) $(LIBFLAGS) $(CFLAGS) $(OBJS) $(LIBS) $(LDFLAGS)
 	$(LIB_EXTRA)
 
 lib: $(LIBTARGET)


### PR DESCRIPTION
LDFLAGS may be passed by the calling process and were correctly applied during the build of blink1-tool executable but not for the attached library. Just add the missing flags to linker step.

---

Hi,

I have tried to (cross-)compile blink1-tool in [Yocto](https://www.yoctoproject.org/) for Raspberry Pi. The build environment passes LDFLAGS as an environment variable and expects them to be applied by the linker.
Without the modification, QA tests complain with such an error:
`ERROR: blink1-tool-2.3.0-r0 do_package_qa: QA Issue: File /usr/lib/libblink1.so in package blink1-tool doesn't have GNU_HASH (didn't pass LDFLAGS?) [ldflags]`

LDFLAGS from Yocto:
```
export LDFLAGS="-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fmacro-prefix-map=/home/jonathan/workset/raspberry/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/blink1-tool/2.3.0-r0=/usr/src/debug/blink1-tool/2.3.0-r0                      -fdebug-prefix-map=/home/jonathan/workset/raspberry/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/blink1-tool/2.3.0-r0=/usr/src/debug/blink1-tool/2.3.0-r0                      -fdebug-prefix-map=/home/jonathan/workset/raspberry/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/blink1-tool/2.3.0-r0/recipe-sysroot=                      -fdebug-prefix-map=/home/jonathan/workset/raspberry/build/tmp/work/cortexa7t2hf-neon-vfpv4-poky-linux-gnueabi/blink1-tool/2.3.0-r0/recipe-sysroot-native=  -Wl,-z,relro,-z,now"
```

I have just added LDFLAGS to `$(LIBTARGET)` target just like it is already done for `blink1-tool` target.