### PR TITLE
Static analysis

### DIFF
--- a/blink1-lib.c
+++ b/blink1-lib.c
@@ -20,6 +20,7 @@
 #define strcasecmp  _stricmp   // POSIX; MSVC equivalent is _stricmp
 #else
 #include <unistd.h>
+#include <strings.h>
 #endif
 
 #include "blink1-lib.h"

--- a/blink1-lib.c
+++ b/blink1-lib.c
@@ -158,7 +158,7 @@ blink1Type_t blink1_deviceTypeById( int i )
     return blink1_infos[i].type;
 }
 
-// returns BLINK1_MK1, BLINK1_MK2, BLINK1_MK3, or BLINK1_MK4 
+// returns BLINK1_MK1, BLINK1_MK2, BLINK1_MK3, or BLINK1_MK4
 blink1Type_t blink1_deviceType( blink1_device* dev )
 {
   return blink1_deviceTypeById( blink1_getCacheIndexByDev(dev) );
@@ -191,7 +191,7 @@ int blink1_isMk2( blink1_device* dev )
     return blink1_isMk2ById( blink1_getCacheIndexByDev(dev) );
 }
 
-const int blink1_getPattMax(blink1_device* dev) {
+int blink1_getPattMax(blink1_device* dev) {
   return blink1_pattMaxes[blink1_deviceType(dev)];
 }
 
@@ -855,7 +855,7 @@ int parsePattern(char* pattstr, int* repeats, patternline_t* pattern)
 {
     char str[1000];
     sprintf(str, "%s", pattstr);  // FIXME: check size
-    
+
     remove_whitespace(str);
     char* s;
     s = strtok( str, ", ");

--- a/blink1-lib.h
+++ b/blink1-lib.h
@@ -76,7 +76,7 @@ typedef struct hid_device_ blink1_device; /* opaque blink1 structure */
 
 // Set blink1_lib_verbose to 1 to enable low-level debugging
 extern int blink1_lib_verbose;
-    
+
 typedef struct {
     uint8_t r; uint8_t g; uint8_t b;
 } rgb_t;
@@ -523,9 +523,9 @@ blink1Type_t blink1_deviceType( blink1_device* dev );
 const char* blink1_deviceTypeToStr(blink1Type_t t);
 
 
-const int blink1_getPattMax(blink1_device* dev);
-  
-  
+int blink1_getPattMax(blink1_device* dev);
+
+
 /**
  * Take an array of bytes and spit them out as a hex string to fp
  */
@@ -565,7 +565,7 @@ int parsePattern( char* str, int* repeats, patternline_t* pattern );
  * Returns length of string created
  */
 int toPatternString(patternline_t* pattern, int pattlen, int repeats, char* pattstr);
-    
+
 /**
  * printf that can be shut up
  *

--- a/blink1-tool.c
+++ b/blink1-tool.c
@@ -11,7 +11,6 @@
  */
 
 #include <stdio.h>
-#include <stdarg.h>    // vararg stuff
 #include <string.h>    // for memset(), strcmp(), et al
 #include <stdlib.h>
 #include <stdint.h>

--- a/blink1control-tool/Makefile
+++ b/blink1control-tool/Makefile
@@ -109,7 +109,7 @@ CFLAGS += -DBLINK1_VERSION=\"$(BLINK1_VERSION)\"
 
 CFLAGS += -lm
 # to fix usleep() not being found on Ubuntu14
-CFLAGS += -D_BSD_SOURCE
+CFLAGS += -D_DEFAULT_SOURCE
 
 CFLAGS += -Wno-pointer-to-int-cast
 CFLAGS +=  -I json-parser

--- a/server/blink1-tiny-server.c
+++ b/server/blink1-tiny-server.c
@@ -21,9 +21,14 @@
  */
 
 #include <getopt.h>    // for getopt_long_only()
-#include <sys/time.h>
 #include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "mongoose.h"  // HTTP server
 #include "parson.h"    // JSON build and parse


### PR DESCRIPTION
This PR introduces applies fixes based on static analysis recommendations. It cleans up header file inclusions, updates deprecated feature test macros to modern standards, and resolves redundant type qualifier warnings.

## Key Changes

### 1. Apply IWYU (Include What You Use) Recommendations

- Refactored library and tool source files to strictly follow IWYU guidelines.
- Removed redundant header inclusions and explicitly added missing direct headers, improving compilation efficiency and file organization.

### 2. Modernize Feature Test Macros ( `_BSD_SOURCE` -> `_DEFAULT_SOURCE` )

- Replaced the deprecated `_BSD_SOURCE` macro with `_DEFAULT_SOURCE` across affected files.
- This resolves glibc compiler warnings on modern Linux distributions while retaining compatibility.

### 3. Fix Redundant `const` Return Type Qualifier

- Removed a redundant `const` qualifier from the return type of the `blink1_getPattMax()` function definition.
- `const` is redundant for basic scalar types that are return by value.
- This resolves compiler/linter warnings about `const` being ignored on scalar return types.

## Impact & Benefits

- Cleaner Build Logs: Eliminates compiler/static analyzer warnings regarding deprecations and redundant type qualifiers.
- Better Maintainability: Improved header hygiene makes the codebase easier to understand and reduces compile-time dependency coupling.
- Standardization: Aligns system macro definitions with modern POSIX/glibc expectations.

## Verification & Testing

- Verified that the project builds clean without errors.
- Confirmed compiler warnings related to `_BSD_SOURCE` and `const` return types are resolved.
- Verified no issues running `blink1-tool` on three different MK3s