### PR TITLE
Makefile: create destination dirs in install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -641,6 +641,7 @@ cpbuilds:
 	@echo "Look in 'builds' for zipfiles to publish"
 
 install-lib:
+	@mkdir -p $(DESTDIR)$(LIBLOCATION)
 	$(INSTALL) $(LIBTARGET) $(DESTDIR)$(LIBLOCATION)/$(LIBTARGET)
 
 install-dev: install-lib makepkgconfig
@@ -648,6 +649,7 @@ install-dev: install-lib makepkgconfig
 	$(INSTALL) blink1-lib.h $(DESTDIR)$(INCLOCATION)/blink1-lib.h
 
 install: all install-lib
+	@mkdir -p $(DESTDIR)$(EXELOCATION)
 	$(INSTALL) blink1-tool$(EXE) $(DESTDIR)$(EXELOCATION)/blink1-tool$(EXE)
 
 uninstall-lib:
@@ -733,4 +735,3 @@ test-blink1-lib: $(OBJS)
 	./tests/test-blink1-lib
 
 test: test-blink1-lib test-blink1-tiny-server
-


### PR DESCRIPTION
`make install` fails when the target bin/lib directories don't already exist under PREFIX. On macOS the Makefile sets `INSTALL = install` (BSD install has no `-D` flag, unlike the Linux branch which uses `install -D`), and the install recipes copy straight into $(EXELOCATION)/$(LIBLOCATION) without creating them first:

    install libBlink1.dylib /<prefix>/lib/libBlink1.dylib
    install: cannot create regular file '/<prefix>/lib/libBlink1.dylib':
             No such file or directory
    make: *** [install-lib] Error 1

Reproduce:
    make install PREFIX=$(mktemp -d)